### PR TITLE
reflect Bootstrap's branding change in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ BootsFaces
 
 BootsFaces : the next gen JSF Framework that takes the best from
 
-Twitter Bootstrap 3 and jQuery UI to let you develop Front-end Enterprise Applications fast and easy.
+Bootstrap 3 and jQuery UI to let you develop Front-end Enterprise Applications fast and easy.
 
 http://www.bootsfaces.net/
 


### PR DESCRIPTION
"Twitter Bootstrap" is now simply "Bootstrap".
Per http://getbootstrap.com/about/#brand
